### PR TITLE
fix: Fix `add-path` deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: 12
     - name: yarn install
       run: |
-        echo "::add-path::$(yarn global bin)"
+        echo "$(yarn global bin)" >> $GITHUB_PATH
         yarn install --frozen-lockfile
         yarn global add @sentry/cli
 


### PR DESCRIPTION
Due to a security vulnerability, `add-path` is deprecated, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/