### PR TITLE
ref(upload): parallelize upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@sentry/integrations": "^5.27.4",
     "@sentry/node": "^5.27.4",
     "@sentry/tracing": "^5.27.4",
+    "@supercharge/promise-pool": "^2.1.0",
     "@types/async-retry": "^1.4.2",
     "@types/bent": "^7.3.0",
     "@types/ejs": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@sentry/integrations": "^5.27.4",
     "@sentry/node": "^5.27.4",
     "@sentry/tracing": "^5.27.4",
-    "@supercharge/promise-pool": "^2.1.0",
     "@types/async-retry": "^1.4.2",
     "@types/bent": "^7.3.0",
     "@types/ejs": "^3.0.4",

--- a/src/util/uploadToGcs.ts
+++ b/src/util/uploadToGcs.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import {PromisePool} from '@supercharge/promise-pool';
 
 import {getStorageClient} from './getStorageClient';
 
@@ -21,28 +22,29 @@ export async function uploadToGcs({
     return Promise.resolve([]);
   }
 
-  const resultPromises: Promise<{alt: string; image_url: string}>[] = [];
+  const results: {alt: string; image_url: string}[] = [];
   const bucketReference = storage.bucket(bucket);
 
-  for (const file of files) {
-    const relativeFilePath = path.relative(root, file);
-    const uploadPromise = bucketReference
-      .upload(file, {
-        destination: `${destinationRoot}/${relativeFilePath}`,
-        gzip: true,
-        metadata: {
-          cacheControl: 'public, max-age=31536000',
-        },
-      })
-      .then(([File]) => ({
-        alt: relativeFilePath,
-        image_url: `https://storage.googleapis.com/${bucket}/${File.name}`,
-      }));
+  await PromisePool.for(files)
+    .withConcurrency(10)
+    .process(async file => {
+      const relativeFilePath = path.relative(root, file);
 
-    resultPromises.push(uploadPromise);
-  }
+      await bucketReference
+        .upload(file, {
+          destination: `${destinationRoot}/${relativeFilePath}`,
+          gzip: true,
+          metadata: {
+            cacheControl: 'public, max-age=31536000',
+          },
+        })
+        .then(([File]) => {
+          results.push({
+            alt: relativeFilePath,
+            image_url: `https://storage.googleapis.com/${bucket}/${File.name}`,
+          });
+        });
+    });
 
-  return Promise.all(resultPromises).then(results =>
-    results.filter(r => r.image_url.includes('/diffs/'))
-  );
+  return results.filter(({image_url}) => image_url.includes('/diffs/'));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@supercharge/promise-pool@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@supercharge/promise-pool/-/promise-pool-2.1.0.tgz#7e9bc2e55060a77641858b391fa8439228457fff"
+  integrity sha512-YEKOfn4xF+DQ61UY5NwHNtr8hYjwchXjGTocVJDAHLQceIRZF8VECH7gumFbp+aGTfygPbMbEtBumXJ/mcJz+w==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,11 +984,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@supercharge/promise-pool@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@supercharge/promise-pool/-/promise-pool-2.1.0.tgz#7e9bc2e55060a77641858b391fa8439228457fff"
-  integrity sha512-YEKOfn4xF+DQ61UY5NwHNtr8hYjwchXjGTocVJDAHLQceIRZF8VECH7gumFbp+aGTfygPbMbEtBumXJ/mcJz+w==
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
Since all the files are generated, we can trigger an upload and saturate the network instead of awaiting each file to upload.
I tried checking our sentry dashboard on how long this step takes, but we cannot see the upload span in our dashboard because we are exceeding the span limit.

Tests results (uploading 848 snapshots)
- **sequential** timed out https://github.com/getsentry/sentry/pull/34355/checks?check_run_id=6394113486 
this run took more than 50minutes, the 2nd time I triggered it should show [here](https://sentry.io/organizations/sentry/performance/summary/?project=5324467&query=transaction.duration%3A%3C15m+transaction.op%3Arun+head_ref%3Ajb%2Ftest%2Fvisual-snapshots-no-concurrency&statsPeriod=24h&transaction=visual+snapshot&unselectedSeries=p100%28%29) if it ever finishes
- **concurrency = 10** (49.79s) [transaction in sentry](https://sentry.io/organizations/sentry/performance/summary/?project=5324467&query=transaction.duration%3A%3C15m+transaction.op%3Arun+head_ref%3Ajb%2Ftest%2Fvisual-snapshots-concurrency-10&statsPeriod=24h&transaction=visual+snapshot&unselectedSeries=p100%28%29)
- **letting node deal with it** (25.74) [transaction in sentry](https://sentry.io/organizations/sentry/performance/summary/?project=5324467&query=transaction.duration%3A%3C15m+transaction.op%3Arun+head_ref%3Ajb%2Ftest%2Fvisual-snapshots-saturate-network&statsPeriod=24h&transaction=visual+snapshot&unselectedSeries=p100%28%29)

It probably does not make a significant difference between setting concurrency to some reasonable amount like 20 vs just shoving it all down the network and letting node deal with it. With the current state of our Sentry repo, even after totally changing the theme file with color changes, we end up uploading something like 850 snapshots, some of those are very small and they upload in a matter of hundreds of milliseconds so max concurrent connections shouldn't be a problem.

One practical consideration: assuming someone creates a PR that changes a significant amount of snapshots, does having _all_ of the snapshots that have changed help them significantly vs having a subset of those changes? In other words, what is the minimum amount of snapshots that we can show for a PR that introduces a big change so that the developer knows what they did wrong? For practical considerations, we could consider capping the diffing and uploading to some 
reasonably high number which would allow us to both early return and upload less data.