### PR TITLE
ref(diffSnapshots): remove fileSpan

### DIFF
--- a/src/util/diffSnapshots.ts
+++ b/src/util/diffSnapshots.ts
@@ -137,10 +137,6 @@ export async function diffSnapshots({
   // face OOM issues
   for (const absoluteFile of currentFiles) {
     const file = path.relative(currentPath, absoluteFile);
-    const fileSpan = span?.startChild({
-      op: 'diff snapshot',
-      description: file,
-    });
     currentSnapshots.add(file);
 
     if (baseSnapshots.has(file)) {
@@ -188,8 +184,6 @@ export async function diffSnapshots({
     } else {
       newSnapshots.add(file);
     }
-
-    fileSpan?.finish();
   }
 
   // TODO: Track cases where snapshot exists in `mergeBaseSnapshots`, but not


### PR DESCRIPTION
We are being limited by the UI to show spans after diffing snapshots because we are exceeding the limit span limit. The spans on files themselves do not seem to be particularly interesting (I would expect diffing to have linear performance with file size as the diffs basically compare px by px from both images).

<img width="2031" alt="CleanShot 2022-05-11 at 08 35 19@2x" src="https://user-images.githubusercontent.com/9317857/167851236-fb839fcb-9374-4999-bd3a-6c80b610f996.png">
 