### PR TITLE
feat: only query for successful workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
         git add dist/index.js
         git add dist/sourcemap-register.js
         git add src/template/index.ts
-        git commit -m "chore(): Updating dist"
-        git push
+        # This can fail if `dist` was already run in branch
+        git commit -m "chore(): Updating dist" | true
+        git push | true
 
     - name: Sentry Release
       env:

--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -9,7 +9,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
           head_sha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
           run_number: 172,
           event: 'push',
-          status: 'success',
+          status: 'completed',
           conclusion: 'success',
           workflow_id: 1154499,
           url:
@@ -53,7 +53,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
           head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
           run_number: 171,
           event: 'push',
-          status: 'success',
+          status: 'completed',
           conclusion: 'success',
           workflow_id: 1154498,
           url:

--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -5,7 +5,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
         {
           id: 152081708,
           node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
-          head_branch: 'master',
+          head_branch: 'main',
           head_sha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
           run_number: 172,
           event: 'push',
@@ -49,7 +49,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
         {
           id: 152081707,
           node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
-          head_branch: 'master',
+          head_branch: 'main',
           head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
           run_number: 171,
           event: 'push',

--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -9,7 +9,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
           head_sha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
           run_number: 172,
           event: 'push',
-          status: 'completed',
+          status: 'success',
           conclusion: 'success',
           workflow_id: 1154499,
           url:
@@ -53,7 +53,7 @@ const listWorkflowRunsMock = jest.fn(async () =>
           head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
           run_number: 171,
           event: 'push',
-          status: 'completed',
+          status: 'success',
           conclusion: 'success',
           workflow_id: 1154498,
           url:

--- a/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
+++ b/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
@@ -18,7 +18,7 @@ test('it gets workflow runs and a branch and workflow id and then gets artifacts
     workflow_id: 'acceptance.yml',
     branch: 'main',
     per_page: 10,
-    status: 'completed',
+    status: 'success',
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({

--- a/__tests__/api/retrieveBaseSnapshots.test.ts
+++ b/__tests__/api/retrieveBaseSnapshots.test.ts
@@ -6,7 +6,7 @@ jest.mock('@app/api/downloadOtherWorkflowArtifact', () => ({
   downloadOtherWorkflowArtifact: jest.fn(),
 }));
 
-test('only downloads and returns base if base and merge base are the same', async function() {
+test('only downloads and returns base if base and merge base are the same', async function () {
   const octokit = github.getOctokit('token');
 
   const results = await retrieveBaseSnapshots(octokit, {
@@ -26,7 +26,7 @@ test('only downloads and returns base if base and merge base are the same', asyn
     workflow_id: 'acceptance.yml',
     branch: 'main',
     per_page: 10,
-    status: 'completed',
+    status: 'success',
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
@@ -54,7 +54,7 @@ test('only downloads and returns base if base and merge base are the same', asyn
   ]);
 });
 
-test('downloads and returns base and merge base', async function() {
+test('downloads and returns base and merge base', async function () {
   const octokit = github.getOctokit('token');
 
   const results = await retrieveBaseSnapshots(octokit, {
@@ -75,7 +75,7 @@ test('downloads and returns base and merge base', async function() {
     workflow_id: 'acceptance.yml',
     branch: 'main',
     per_page: 10,
-    status: 'completed',
+    status: 'success',
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({

--- a/src/api/getArtifactsForBranchAndWorkflow.ts
+++ b/src/api/getArtifactsForBranchAndWorkflow.ts
@@ -62,7 +62,7 @@ export async function getArtifactsForBranchAndWorkflow(
       // Below is typed incorrectly, it needs to be a string but typed as number
       workflow_id: (workflow_id as unknown) as number,
       branch,
-      status: 'completed',
+      status: 'success',
       per_page: PER_PAGE_LIMIT,
     }
   )) {


### PR DESCRIPTION
The previous behavior could include "skipped" workflows that would have a status as `completed`.

Also include some other minor fixes to release workflow and test mocks