### PR TITLE
feat: Upgrade `actions/github` and other gh actions

### DIFF
--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -108,45 +108,79 @@ export const getOctokit = jest.fn(() => ({
       };
     },
   },
+  rest: {
+    actions: {
+      downloadArtifact: jest.fn(async () =>
+        Promise.resolve({
+          status: 200,
+          url:
+            'https://pipelines.actions.githubusercontent.com/fVNRiR9dLg3DkWCpAUCEq7qRezdKTcYtICIqwx0vWs6L0oyqxQ/_apis/pipelines/1/runs/487/signedartifactscontent?artifactName=visual-snapshots&urlExpires=2020-06-30T00%3A19%3A19.8133132Z&urlSigningMethod=HMACV1&urlSignature=12tWt93zqyKS9Fy7IMRj1NGHxGn07YTDwOZT988hCAI%3D',
+          headers: {
+            activityid: '6f102bff-9bb1-417c-b287-11fe2590b59f',
+            'cache-control': 'no-store,no-cache',
+            connection: 'close',
+            'content-disposition':
+              "attachment; filename=visual-snapshots.zip; filename*=UTF-8''visual-snapshots.zip",
+            'content-type': 'application/zip',
+            date: 'Tue, 30 Jun 2020 00:18:19 GMT',
+            pragma: 'no-cache',
+            'strict-transport-security': 'max-age=2592000',
+            'transfer-encoding': 'chunked',
+            'x-msedge-ref':
+              'Ref A: E43B909F46624B43B8BF124E065BA79F Ref B: BL2EDGE1012 Ref C: 2020-06-30T00:18:19Z',
+            'x-tfs-processid': 'c89a355b-8563-4622-8185-9522d07edc84',
+            'x-tfs-session': '6f102bff-9bb1-417c-b287-11fe2590b59f',
+            'x-vss-e2eid': '6f102bff-9bb1-417c-b287-11fe2590b59f',
+            'x-vss-senderdeploymentid': '193695a0-0dcd-ade4-f810-b10ad24a9829',
+          },
+          data: {},
+        })
+      ),
+      listWorkflowRuns: listWorkflowRunsMock,
+      listWorkflowRunArtifacts: jest.fn(async opts => {
+        if (opts.run_id === 152081707) {
+          return Promise.resolve({
+            data: {
+              artifacts: [
+                {
+                  id: 8808920,
+                  node_id: '',
+                  name: 'visual-snapshots',
+                  size_in_bytes: 11768445,
+                  url:
+                    'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
+                  archive_download_url:
+                    'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919/zip',
+                  expired: false,
+                  created_at: '2020-06-29T23:56:36Z',
+                  updated_at: '2020-06-29T23:56:40Z',
+                },
+              ],
+            },
+          });
+        }
 
-  actions: {
-    downloadArtifact: jest.fn(async () =>
-      Promise.resolve({
-        status: 200,
-        url:
-          'https://pipelines.actions.githubusercontent.com/fVNRiR9dLg3DkWCpAUCEq7qRezdKTcYtICIqwx0vWs6L0oyqxQ/_apis/pipelines/1/runs/487/signedartifactscontent?artifactName=visual-snapshots&urlExpires=2020-06-30T00%3A19%3A19.8133132Z&urlSigningMethod=HMACV1&urlSignature=12tWt93zqyKS9Fy7IMRj1NGHxGn07YTDwOZT988hCAI%3D',
-        headers: {
-          activityid: '6f102bff-9bb1-417c-b287-11fe2590b59f',
-          'cache-control': 'no-store,no-cache',
-          connection: 'close',
-          'content-disposition':
-            "attachment; filename=visual-snapshots.zip; filename*=UTF-8''visual-snapshots.zip",
-          'content-type': 'application/zip',
-          date: 'Tue, 30 Jun 2020 00:18:19 GMT',
-          pragma: 'no-cache',
-          'strict-transport-security': 'max-age=2592000',
-          'transfer-encoding': 'chunked',
-          'x-msedge-ref':
-            'Ref A: E43B909F46624B43B8BF124E065BA79F Ref B: BL2EDGE1012 Ref C: 2020-06-30T00:18:19Z',
-          'x-tfs-processid': 'c89a355b-8563-4622-8185-9522d07edc84',
-          'x-tfs-session': '6f102bff-9bb1-417c-b287-11fe2590b59f',
-          'x-vss-e2eid': '6f102bff-9bb1-417c-b287-11fe2590b59f',
-          'x-vss-senderdeploymentid': '193695a0-0dcd-ade4-f810-b10ad24a9829',
-        },
-        data: {},
-      })
-    ),
-    listWorkflowRuns: listWorkflowRunsMock,
-    listWorkflowRunArtifacts: jest.fn(async opts => {
-      if (opts.run_id === 152081707) {
         return Promise.resolve({
           data: {
             artifacts: [
               {
-                id: 8808920,
-                node_id: '',
+                id: 9808920,
+                node_id: 'MDg6QXJ0aWZhY3Q5ODA4OTE5',
+                name: 'not-visual-snapshots',
+                size_in_bytes: 11768446,
+                url:
+                  'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919/zip',
+                expired: false,
+                created_at: '2020-06-29T23:56:36Z',
+                updated_at: '2020-06-29T23:56:40Z',
+              },
+              {
+                id: 9808919,
+                node_id: 'MDg6QXJ0aWZhY3Q5ODA4OTE5',
                 name: 'visual-snapshots',
-                size_in_bytes: 11768445,
+                size_in_bytes: 11768446,
                 url:
                   'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
                 archive_download_url:
@@ -158,40 +192,7 @@ export const getOctokit = jest.fn(() => ({
             ],
           },
         });
-      }
-
-      return Promise.resolve({
-        data: {
-          artifacts: [
-            {
-              id: 9808920,
-              node_id: 'MDg6QXJ0aWZhY3Q5ODA4OTE5',
-              name: 'not-visual-snapshots',
-              size_in_bytes: 11768446,
-              url:
-                'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919/zip',
-              expired: false,
-              created_at: '2020-06-29T23:56:36Z',
-              updated_at: '2020-06-29T23:56:40Z',
-            },
-            {
-              id: 9808919,
-              node_id: 'MDg6QXJ0aWZhY3Q5ODA4OTE5',
-              name: 'visual-snapshots',
-              size_in_bytes: 11768446,
-              url:
-                'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919/zip',
-              expired: false,
-              created_at: '2020-06-29T23:56:36Z',
-              updated_at: '2020-06-29T23:56:40Z',
-            },
-          ],
-        },
-      });
-    }),
+      }),
+    },
   },
 }));

--- a/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
+++ b/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
@@ -12,7 +12,7 @@ test('it gets workflow runs and a branch and workflow id and then gets artifacts
     artifactName: 'visual-snapshots',
   });
 
-  expect(octokit.actions.listWorkflowRuns).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
@@ -21,7 +21,7 @@ test('it gets workflow runs and a branch and workflow id and then gets artifacts
     status: 'completed',
   });
 
-  expect(octokit.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     run_id: 152081708,

--- a/__tests__/api/retrieveBaseSnapshots.test.ts
+++ b/__tests__/api/retrieveBaseSnapshots.test.ts
@@ -20,7 +20,7 @@ test('only downloads and returns base if base and merge base are the same', asyn
     mergeBaseSha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
   });
 
-  expect(octokit.actions.listWorkflowRuns).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
@@ -29,13 +29,13 @@ test('only downloads and returns base if base and merge base are the same', asyn
     status: 'completed',
   });
 
-  expect(octokit.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     run_id: 152081708,
   });
 
-  expect(octokit.actions.listWorkflowRuns).toHaveBeenCalledTimes(1);
+  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledTimes(1);
 
   expect(downloadOtherWorkflowArtifact).toHaveBeenCalledTimes(1);
   expect(downloadOtherWorkflowArtifact).toHaveBeenCalledWith(octokit, {
@@ -68,8 +68,8 @@ test('downloads and returns base and merge base', async function() {
     mergeBaseSha: '11111111l129a173dc79d4634df0fdaece933b06',
   });
 
-  expect(octokit.actions.listWorkflowRuns).toHaveBeenCalledTimes(2);
-  expect(octokit.actions.listWorkflowRuns).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledTimes(2);
+  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
@@ -78,13 +78,13 @@ test('downloads and returns base and merge base', async function() {
     status: 'completed',
   });
 
-  expect(octokit.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     run_id: 152081708,
   });
 
-  expect(octokit.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
+  expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
     owner: 'getsentry',
     repo: 'sentry',
     run_id: 152081707,

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "node-forge": "^0.10.0"
   },
   "dependencies": {
-    "@actions/artifact": "^0.4.0",
+    "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.8.2",
-    "@actions/exec": "^1.0.4",
+    "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
-    "@actions/glob": "^0.1.0",
-    "@actions/io": "^1.0.2",
+    "@actions/glob": "^0.3.0",
+    "@actions/io": "^1.1.2",
     "@google-cloud/storage": "^5.4.0",
     "@sentry/integrations": "^5.27.4",
     "@sentry/node": "^5.27.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "dependencies": {
     "@actions/artifact": "^0.4.0",
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.8.2",
     "@actions/exec": "^1.0.4",
-    "@actions/github": "^4.0.0",
+    "@actions/github": "^5.0.3",
     "@actions/glob": "^0.1.0",
     "@actions/io": "^1.0.2",
     "@google-cloud/storage": "^5.4.0",

--- a/src/api/downloadOtherWorkflowArtifact.ts
+++ b/src/api/downloadOtherWorkflowArtifact.ts
@@ -69,7 +69,7 @@ export async function downloadOtherWorkflowArtifact(
   octokit: ReturnType<typeof github.getOctokit>,
   {owner, repo, artifactId, downloadPath}: DownloadArtifactParams
 ) {
-  const artifact = await octokit.actions.downloadArtifact({
+  const artifact = await octokit.rest.actions.downloadArtifact({
     owner,
     repo,
     artifact_id: artifactId,

--- a/src/api/failBuild.ts
+++ b/src/api/failBuild.ts
@@ -40,8 +40,7 @@ export async function failBuild({token, octokit, ...body}: Params) {
 
   const {title, summary, ...checkBody} = failureBody;
 
-  // @ts-ignore
-  return await octokit.checks.update({
+  return await octokit.rest.checks.update({
     check_run_id: id,
     owner,
     repo,

--- a/src/api/finishBuild.ts
+++ b/src/api/finishBuild.ts
@@ -55,7 +55,7 @@ export async function finishBuild({token, ...body}: Params) {
         ? `${added.length} new snapshots`
         : 'No snapshot changes detected';
 
-    return await octokit.checks.update({
+    return await octokit.rest.checks.update({
       check_run_id: id,
       owner,
       repo,

--- a/src/api/getArtifactsForBranchAndWorkflow.ts
+++ b/src/api/getArtifactsForBranchAndWorkflow.ts
@@ -4,10 +4,10 @@ import * as github from '@actions/github';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 type WorkflowRun = GetResponseDataTypeFromEndpointMethod<
-  Octokit['actions']['listWorkflowRuns']
+  Octokit['rest']['actions']['listWorkflowRuns']
 >['workflow_runs'][number];
 type Artifacts = GetResponseDataTypeFromEndpointMethod<
-  Octokit['actions']['listWorkflowRunArtifacts']
+  Octokit['rest']['actions']['listWorkflowRunArtifacts']
 >['artifacts'][number];
 
 export type GetArtifactsForBranchAndWorkflowReturn = {
@@ -55,7 +55,7 @@ export async function getArtifactsForBranchAndWorkflow(
   let completedWorkflowRuns: WorkflowRun[] = [];
 
   for await (const response of octokit.paginate.iterator(
-    octokit.actions.listWorkflowRuns,
+    octokit.rest.actions.listWorkflowRuns,
     {
       owner,
       repo,
@@ -114,7 +114,7 @@ export async function getArtifactsForBranchAndWorkflow(
 
     const {
       data: {artifacts},
-    } = await octokit.actions.listWorkflowRunArtifacts({
+    } = await octokit.rest.actions.listWorkflowRunArtifacts({
       owner,
       repo,
       run_id: workflowRun.id,

--- a/src/api/startBuild.ts
+++ b/src/api/startBuild.ts
@@ -48,7 +48,7 @@ export async function startBuild({
     core.endGroup();
 
     core.startGroup('Starting build using GitHub API directly...');
-    const {data: check} = await octokit.checks.create({
+    const {data: check} = await octokit.rest.checks.create({
       owner,
       repo,
       head_sha,

--- a/src/main.ts
+++ b/src/main.ts
@@ -205,7 +205,7 @@ async function run(): Promise<void> {
         // TODO: fail the build if workflow_run.conclusion != 'success'
         // If this is called from a `workflow_run` event, then assume that the artifacts exist from that workflow run
         // TODO: I'm not sure what happens if there are multiple workflows defined (I assume it would get called multiple times?)
-        const {data} = await octokit.actions.listWorkflowRunArtifacts({
+        const {data} = await octokit.rest.actions.listWorkflowRunArtifacts({
           owner,
           repo,
           run_id: workflowRunPayload?.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,10 +13,17 @@
     tmp "^0.1.0"
     tmp-promise "^2.0.2"
 
-"@actions/core@^1.2.0", "@actions/core@^1.2.1", "@actions/core@^1.2.6":
+"@actions/core@^1.2.0", "@actions/core@^1.2.1":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
   integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
+
+"@actions/core@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.8.2.tgz#67539d669ae9b751430469e9ae4d83e0525973ac"
+  integrity sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
 
 "@actions/exec@^1.0.4":
   version "1.0.4"
@@ -25,15 +32,15 @@
   dependencies:
     "@actions/io" "^1.0.1"
 
-"@actions/github@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@actions/github/-/github-4.0.0.tgz#d520483151a2bf5d2dc9cd0f20f9ac3a2e458816"
-  integrity sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==
+"@actions/github@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-5.0.3.tgz#b305765d6173962d113451ea324ff675aa674f35"
+  integrity sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==
   dependencies:
-    "@actions/http-client" "^1.0.8"
-    "@octokit/core" "^3.0.0"
-    "@octokit/plugin-paginate-rest" "^2.2.3"
-    "@octokit/plugin-rest-endpoint-methods" "^4.0.0"
+    "@actions/http-client" "^2.0.1"
+    "@octokit/core" "^3.6.0"
+    "@octokit/plugin-paginate-rest" "^2.17.0"
+    "@octokit/plugin-rest-endpoint-methods" "^5.13.0"
 
 "@actions/glob@^0.1.0":
   version "0.1.0"
@@ -43,12 +50,19 @@
     "@actions/core" "^1.2.0"
     minimatch "^3.0.4"
 
-"@actions/http-client@^1.0.7", "@actions/http-client@^1.0.8":
+"@actions/http-client@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.8.tgz#8bd76e8eca89dc8bcf619aa128eba85f7a39af45"
   integrity sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==
   dependencies:
     tunnel "0.0.6"
+
+"@actions/http-client@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.0.1.tgz#873f4ca98fe32f6839462a6f046332677322f99c"
+  integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
+  dependencies:
+    tunnel "^0.0.6"
 
 "@actions/io@^1.0.1", "@actions/io@^1.0.2":
   version "1.0.2"
@@ -798,23 +812,24 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@octokit/auth-token@^2.4.0":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
-  integrity sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==
+"@octokit/auth-token@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
   dependencies:
-    "@octokit/types" "^5.0.0"
+    "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.0.0":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.1.2.tgz#c937d5f9621b764573068fcd2e5defcc872fd9cc"
-  integrity sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==
+"@octokit/core@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
   dependencies:
-    "@octokit/auth-token" "^2.4.0"
-    "@octokit/graphql" "^4.3.1"
-    "@octokit/request" "^5.4.0"
-    "@octokit/types" "^5.0.0"
-    before-after-hook "^2.1.0"
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.3"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/endpoint@^6.0.1":
@@ -826,66 +841,69 @@
     is-plain-object "^3.0.0"
     universal-user-agent "^5.0.0"
 
-"@octokit/graphql@^4.3.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.1.tgz#162aed1490320b88ce34775b3f6b8de945529fa9"
-  integrity sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==
+"@octokit/graphql@^4.5.8":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
   dependencies:
-    "@octokit/request" "^5.3.0"
-    "@octokit/types" "^5.0.0"
-    universal-user-agent "^5.0.0"
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
 
-"@octokit/plugin-paginate-rest@^2.2.3":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz#92f951ddc8a1cd505353fa07650752ca25ed7e93"
-  integrity sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==
-  dependencies:
-    "@octokit/types" "^5.5.0"
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
-"@octokit/plugin-rest-endpoint-methods@^4.0.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz#c5a0691b3aba5d8b4ef5dffd6af3649608f167ba"
-  integrity sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==
+"@octokit/plugin-paginate-rest@^2.17.0":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
   dependencies:
-    "@octokit/types" "^5.5.0"
+    "@octokit/types" "^6.34.0"
+
+"@octokit/plugin-rest-endpoint-methods@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
+  dependencies:
+    "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
-"@octokit/request-error@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.2.tgz#0e76b83f5d8fdda1db99027ea5f617c2e6ba9ed0"
-  integrity sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
   dependencies:
-    "@octokit/types" "^5.0.1"
+    "@octokit/types" "^6.0.3"
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.0":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.5.tgz#8df65bd812047521f7e9db6ff118c06ba84ac10b"
-  integrity sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==
+"@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
-    "@octokit/request-error" "^2.0.0"
-    "@octokit/types" "^5.0.0"
-    deprecation "^2.0.0"
-    is-plain-object "^3.0.0"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^5.0.0"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
 
-"@octokit/types@^5.0.0", "@octokit/types@^5.0.1":
+"@octokit/types@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.0.1.tgz#5459e9a5e9df8565dcc62c17a34491904d71971e"
   integrity sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
-  integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
   dependencies:
-    "@types/node" ">= 8"
+    "@octokit/openapi-types" "^11.2.0"
 
 "@sentry/core@5.27.4":
   version "5.27.4"
@@ -1579,10 +1597,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
-  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 bent@^7.3.11:
   version "7.3.11"
@@ -3271,6 +3289,11 @@ is-plain-object@^3.0.0:
   dependencies:
     isobject "^4.0.0"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
@@ -4287,6 +4310,13 @@ node-fetch@^2.2.0, node-fetch@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -5623,6 +5653,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-jest@^26.4.1:
   version "26.4.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.1.tgz#08ec0d3fc2c3a39e4a46eae5610b69fafa6babd0"
@@ -5670,7 +5705,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel@0.0.6:
+tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
@@ -5880,6 +5915,11 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -5901,6 +5941,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0:
   version "8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,33 +2,27 @@
 # yarn lockfile v1
 
 
-"@actions/artifact@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@actions/artifact/-/artifact-0.4.0.tgz#a2e9ba2791a21ddf0028d520d2b481e161027fee"
-  integrity sha512-iPDMvCIogq22F3r11xyBbH2wtUuJYfa3llGM8Kxilx6lVrcGpWa5Bnb1ukD/MEmCn9SBXdz6eqNLa10GQ20HNg==
+"@actions/artifact@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@actions/artifact/-/artifact-1.1.0.tgz#762b2c05795accb464eaf803e7a2b4d6b325846d"
+  integrity sha512-shO+w/BAnzRnFhfsgUao8sxjByAMqDdfvek2LLKeCueBKXoTrAcp7U/hs9Fdx+z9g7Q0mbIrmHAzAAww4HK1bQ==
   dependencies:
-    "@actions/core" "^1.2.1"
-    "@actions/http-client" "^1.0.7"
-    "@types/tmp" "^0.1.0"
-    tmp "^0.1.0"
-    tmp-promise "^2.0.2"
+    "@actions/core" "^1.2.6"
+    "@actions/http-client" "^2.0.1"
+    tmp "^0.2.1"
+    tmp-promise "^3.0.2"
 
-"@actions/core@^1.2.0", "@actions/core@^1.2.1":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
-  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
-
-"@actions/core@^1.8.2":
+"@actions/core@^1.2.6", "@actions/core@^1.8.2":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.8.2.tgz#67539d669ae9b751430469e9ae4d83e0525973ac"
   integrity sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==
   dependencies:
     "@actions/http-client" "^2.0.1"
 
-"@actions/exec@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.0.4.tgz#99d75310e62e59fc37d2ee6dcff6d4bffadd3a5d"
-  integrity sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==
+"@actions/exec@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
+  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
   dependencies:
     "@actions/io" "^1.0.1"
 
@@ -42,20 +36,13 @@
     "@octokit/plugin-paginate-rest" "^2.17.0"
     "@octokit/plugin-rest-endpoint-methods" "^5.13.0"
 
-"@actions/glob@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@actions/glob/-/glob-0.1.0.tgz#969ceda7e089c39343bca3306329f41799732e40"
-  integrity sha512-lx8SzyQ2FE9+UUvjqY1f28QbTJv+w8qP7kHHbfQRhphrlcx0Mdmm1tZdGJzfxv1jxREa/sLW4Oy8CbGQKCJySA==
+"@actions/glob@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@actions/glob/-/glob-0.3.0.tgz#beb5282a8cd936baadbe99fbb1ccd5eaf2d1fc28"
+  integrity sha512-tJP1ZhF87fd6LBnaXWlahkyvdgvsLl7WnreW1EZaC8JWjpMXmzqWzQVe/IEYslrkT9ymibVrKyJN4UMD7uQM2w==
   dependencies:
-    "@actions/core" "^1.2.0"
+    "@actions/core" "^1.2.6"
     minimatch "^3.0.4"
-
-"@actions/http-client@^1.0.7":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.8.tgz#8bd76e8eca89dc8bcf619aa128eba85f7a39af45"
-  integrity sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==
-  dependencies:
-    tunnel "0.0.6"
 
 "@actions/http-client@^2.0.1":
   version "2.0.1"
@@ -64,10 +51,15 @@
   dependencies:
     tunnel "^0.0.6"
 
-"@actions/io@^1.0.1", "@actions/io@^1.0.2":
+"@actions/io@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.0.2.tgz#2f614b6e69ce14d191180451eb38e6576a6e6b27"
   integrity sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg==
+
+"@actions/io@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.2.tgz#766ac09674a289ce0f1550ffe0a6eac9261a8ea9"
+  integrity sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.3":
   version "7.10.3"
@@ -1173,11 +1165,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
-
-"@types/tmp@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
-  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
 "@types/uuid@^8.3.0":
   version "8.3.0"
@@ -5001,13 +4988,6 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -5561,19 +5541,19 @@ through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tmp-promise@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.1.1.tgz#eb97c038995af74efbfe8156f5e07fdd0c935539"
-  integrity sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
   dependencies:
-    tmp "0.1.0"
+    tmp "^0.2.0"
 
-tmp@0.1.0, tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+tmp@^0.2.0, tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
-    rimraf "^2.6.3"
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -5705,7 +5685,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel@0.0.6, tunnel@^0.0.6:
+tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==


### PR DESCRIPTION
`actions/github` has better typing. Biggest change is to call the api methods from `octokit.rest` instead of `octokit`.

### Changelogs

* https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md
* https://github.com/actions/toolkit/blob/main/packages/artifact/RELEASES.md
* https://github.com/actions/toolkit/blob/main/packages/exec/RELEASES.md
* https://github.com/actions/toolkit/blob/main/packages/glob/RELEASES.md
* https://github.com/actions/toolkit/blob/main/packages/io/RELEASES.md