### PR TITLE
feat(sentry): add os tags

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {retrieveBaseSnapshots} from './api/retrieveBaseSnapshots';
 import {startBuild} from './api/startBuild';
 import {finishBuild} from './api/finishBuild';
 import {failBuild} from './api/failBuild';
+import {getOSTags} from './util/osTags';
 import {SENTRY_DSN} from './config';
 import {Await} from './types';
 import {getPixelmatchOptions} from './getPixelmatchOptions';
@@ -360,7 +361,7 @@ const {headRef, headSha} = getGithubHeadRefInfo();
 const transaction = Sentry.startTransaction({
   op: shouldSaveOnly !== 'false' ? 'save snapshots' : 'run',
   name: 'visual snapshot',
-  tags: {head_ref: headRef, head_sha: headSha},
+  tags: {head_ref: headRef, head_sha: headSha, ...getOSTags()},
 });
 
 Sentry.configureScope(scope => {

--- a/src/util/osTags.ts
+++ b/src/util/osTags.ts
@@ -1,0 +1,8 @@
+import os from 'os';
+
+export function getOSTags(): Record<string, string> {
+  return {
+    'os.cpus.total': os.cpus().length.toFixed(0),
+    'os.memory.total': os.totalmem().toFixed(0),
+  };
+}

--- a/src/util/osTags.ts
+++ b/src/util/osTags.ts
@@ -4,5 +4,6 @@ export function getOSTags(): Record<string, string> {
   return {
     'os.cpus.total': os.cpus().length.toFixed(0),
     'os.memory.total': os.totalmem().toFixed(0),
+    'os.memory.free': os.freemem().toFixed(0),
   };
 }


### PR DESCRIPTION
The CI machines vary and we are very likely CPU bound when diffing snapshots. This adds two os level tags that can give us some extra info when looking at the performance data.