### PR TITLE
feat: Set Sentry environment to production when running from main

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,14 +2,10 @@ name: 'action-visual-snapshot'
 description: 'Visual snapshot tester for GitHub Actions'
 author: 'Sentry'
 inputs:
-  _repo:
-    required: false
-    default: ${{ github.action_repository }}
-    description: 'Use to instrospect about the action itself.'
   _ref:
     required: false
     default: ${{ github.action_ref }}
-    description: 'Use to instrospect about the action itself.'
+    description: 'Used for instrospection about the action itself.'
   threshold:
     description: 'Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0.1 by default.'
     default: 0.05

--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,6 @@ name: 'action-visual-snapshot'
 description: 'Visual snapshot tester for GitHub Actions'
 author: 'Sentry'
 inputs:
-  _ref:
-    required: false
-    default: ${{ github.action_ref }}
-    description: 'Used for instrospection about the action itself.'
   threshold:
     description: 'Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0.1 by default.'
     default: 0.05

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,14 @@ name: 'action-visual-snapshot'
 description: 'Visual snapshot tester for GitHub Actions'
 author: 'Sentry'
 inputs:
+  _repo:
+    required: false
+    default: ${{ github.action_repository }}
+    description: 'Use to instrospect about the action itself.'
+  _ref:
+    required: false
+    default: ${{ github.action_ref }}
+    description: 'Use to instrospect about the action itself.'
   threshold:
     description: 'Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0.1 by default.'
     default: 0.05
@@ -79,12 +87,5 @@ outputs:
   merge-base-images-path:
     description: 'path where merge base images are saved'
 runs:
-  using: composite
-  steps:
-  - run: echo "$WAT" "$WAT2"
-    env:
-      WAT: ${{ github.action_repository }}
-      WAT2: ${{ github.action_ref }}
-    shell: bash
-  - run: node dist/index.js
-    shell: bash
+  using: 'node16'
+  main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -79,5 +79,12 @@ outputs:
   merge-base-images-path:
     description: 'path where merge base images are saved'
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: composite
+  steps:
+  - run: echo "$WAT" "$WAT2"
+    env:
+      WAT: ${{ github.action_repository }}
+      WAT2: ${{ github.action_ref }}
+    shell: bash
+  - run: node dist/index.js
+    shell: bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -376,10 +376,13 @@ async function run(): Promise<void> {
 }
 
 const {headRef, headSha} = getGithubHeadRefInfo();
+// core.debug(process.env);
+core.debug(JSON.stringify(process.env, null, 2));
 
 const transaction = Sentry.startTransaction({
   op: shouldSaveOnly !== 'false' ? 'save snapshots' : 'run',
   name: 'visual snapshot',
+  // These values are from where GH action got executed (e.g. values of the PR)
   tags: {head_ref: headRef, head_sha: headSha, ...getOSTags()},
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,6 +378,13 @@ async function run(): Promise<void> {
 const {headRef, headSha} = getGithubHeadRefInfo();
 // core.debug(process.env);
 core.debug(JSON.stringify(process.env, null, 2));
+console.log(process.env.INPUT__REPO);
+console.log(process.env.INPUT__REF);
+const _repo = core.getInput('_repo');
+const _ref = core.getInput('_repo');
+core.debug(_repo);
+core.debug(_ref);
+console.log(_repo);
 
 const transaction = Sentry.startTransaction({
   op: shouldSaveOnly !== 'false' ? 'save snapshots' : 'run',

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,9 @@ const {headRef, headSha} = getGithubHeadRefInfo();
 
 // Only report to Sentry if executing from the main branch
 if (core.getInput('_ref') === 'main') {
+  core.debug(
+    'A performance transaction will be sent to Sentry for the execution of this action.'
+  );
   const transaction = Sentry.startTransaction({
     op: shouldSaveOnly !== 'false' ? 'save snapshots' : 'run',
     name: 'visual snapshot',
@@ -395,5 +398,6 @@ if (core.getInput('_ref') === 'main') {
 
   run().then(() => transaction.finish());
 } else {
+  core.debug('No transaction will be submitted to Sentry for this run.');
   run();
 }


### PR DESCRIPTION
You can see a sample `development` error [here](https://sentry.io/organizations/sentry/issues/3123211249/?environment=development&project=5324467&query=is%3Aignored&statsPeriod=1h).