### PR TITLE
feat: Rename transaction, report status and required approval tag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -404,7 +404,7 @@ run()
   .then(() => {
     // Since we're doing custom instrumentation we need to set the status, otherwise,
     // all transactions would be marked as Unknown status
-    transaction.setStatus(SpanStatus.Ok);
+    transaction.setStatus(SpanStatus.UnknownError);
   })
   .catch(err => {
     // If an error has not been caugth within the run method we should

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,16 +395,14 @@ Sentry.configureScope(scope => {
 
 let status = SpanStatus.Ok;
 
-run()
-  .catch(err => {
-    // If an error has not been caugth within the run method we should report it
-    // and mark the transaction has failed
-    Sentry.captureException(new Error(err.message));
-    status = SpanStatus.InternalError;
-  })
-  .finally(() => {
-    // Since we're doing custom instrumentation we need to set the status, otherwise,
-    // all transactions would be marked as Unknown status
-    transaction.setStatus(status);
-    transaction.finish();
-  });
+run().catch(err => {
+  // If an error has not been caugth within the run method we should report it
+  // and mark the transaction has failed
+  Sentry.captureException(new Error(err.message));
+  status = SpanStatus.InternalError;
+});
+
+// Since we're doing custom instrumentation we need to set the status, otherwise,
+// all transactions would be marked as Unknown status
+transaction.setStatus(status);
+transaction.finish();

--- a/src/main.ts
+++ b/src/main.ts
@@ -393,16 +393,16 @@ Sentry.configureScope(scope => {
   scope.setSpan(transaction);
 });
 
-let status = SpanStatus.Ok;
-
-run().catch(err => {
-  // If an error has not been caugth within the run method we should report it
-  // and mark the transaction has failed
-  Sentry.captureException(new Error(err.message));
-  status = SpanStatus.InternalError;
-});
-
-// Since we're doing custom instrumentation we need to set the status, otherwise,
-// all transactions would be marked as Unknown status
-transaction.setStatus(status);
-transaction.finish();
+run()
+  .then(() => {
+    // Since we're doing custom instrumentation we need to set the status, otherwise,
+    // all transactions would be marked as Unknown status
+    transaction.setStatus(SpanStatus.Ok);
+  })
+  .catch(err => {
+    // If an error has not been caugth within the run method we should report it
+    // and mark the transaction has failed
+    Sentry.captureException(new Error(err.message));
+    transaction.setStatus(SpanStatus.InternalError);
+  })
+  .finally(() => transaction.finish());

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,6 +315,13 @@ async function run(): Promise<void> {
       missing: [...missingSnapshots],
       added: [...newSnapshots],
     };
+    // This allows using Discover to distinguish transactions that require approval
+    const {changed, missing} = results;
+    if (changed.length + missing.length > 0) {
+      transaction?.setTag('snapshots.approvalRequired', 'true');
+    } else {
+      transaction?.setTag('snapshots.approvalRequired', 'false');
+    }
     core.endGroup();
 
     core.startGroup('Generating image gallery...');
@@ -364,14 +371,6 @@ async function run(): Promise<void> {
         results,
       }),
     ]);
-
-    const {changed, missing} = results;
-    // This allows using Discover to distinguish transactions that require approval
-    if (changed.length + missing.length > 0) {
-      finishSpan?.setTag('requireApproval', 'true');
-    } else {
-      finishSpan?.setTag('requireApproval', 'false');
-    }
     finishSpan?.finish();
   } catch (error) {
     handleError(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -410,7 +410,7 @@ run()
     // If an error has not been caugth within the run method we should
     // report it as an error and mark the transaction as failed
     // Marking the transaction as failed allows using failure_rate() in Discover
-    Sentry.captureException(new Error(err.message));
     transaction.setStatus(SpanStatus.InternalError);
+    Sentry.captureException(err);
   })
   .finally(() => transaction.finish());

--- a/src/main.ts
+++ b/src/main.ts
@@ -389,8 +389,6 @@ async function run(): Promise<void> {
       token: apiToken,
     });
   }
-
-  //
 }
 
 const {headRef, headSha} = getGithubHeadRefInfo();


### PR DESCRIPTION
There's various features in here:

- Setting different titles depending on the action: `save snapshots` vs `run`
  - Before this, they were all named "visual snapshots" even though the top span of each was named correctly
- Report the status of a transaction (instead of currently being always unknown)
  - This can be `Ok` when there are no errors and `InternalError` when anything fails
- Tag a transaction as needing approval or not
  - This is useful to determine how many executions required a human to approve the execution

This means that we will be able to do the following in Discover:
- failure_rate() -> A failure is when the execution fails in an unexpected manner
- requiring approval -> The amount of times a developer is unable to merge a PR until approving a check

[A failure](https://sentry.io/organizations/sentry/discover/visual-snapshot-action:e3ddc354f0924d1891e44b0d965baf04/?environment=development&field=transaction.status&field=timestamp&field=title&field=transaction.duration&name=All+Events&project=5324467&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) has a status of `internal_error`. No tag saying if it requires approval or not.

[A transaction with approval required](https://sentry.io/organizations/sentry/discover/visual-snapshot-action:7eec6ca2f9e0424eb05652591ff4ae63/?environment=development&field=title&field=timestamp&field=transaction.status&name=All+Events&project=5324467&query=title%3Arun&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) and [a transaction with NO approval required](https://sentry.io/organizations/sentry/discover/visual-snapshot-action:216e19a6c9d640f8b53d5009f647b1b9/?environment=development&field=title&field=timestamp&field=transaction.status&field=snapshots.approvalRequired&name=All+Events&project=5324467&query=title%3Arun&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29). Both of them have a status of `Ok`.

Here's a [query](https://sentry.io/organizations/sentry/discover/results/?environment=development&field=title&field=count%28%29&field=count_if%28snapshots.approvalRequired%2Cequals%2Ctrue%29&field=failure_rate%28%29&field=equation%7Ccount_if%28snapshots.approvalRequired%2Cequals%2Ctrue%29+%2F+count%28%29+%2A100&name=All+Events&project=5324467&query=title%3Arun&sort=-title&statsPeriod=7d&yAxis=count%28%29) with data base on this branch.

<img width="933" alt="image" src="https://user-images.githubusercontent.com/44410/174388445-1e035f0a-0d49-403d-9b14-c3ad3e2c79fc.png">
