### PR TITLE
sentry(tags): tag library

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -382,7 +382,12 @@ const {headRef, headSha} = getGithubHeadRefInfo();
 const transaction = Sentry.startTransaction({
   op: shouldSaveOnly !== 'false' ? 'save snapshots' : 'run',
   name: 'visual snapshot',
-  tags: {head_ref: headRef, head_sha: headSha, ...getOSTags()},
+  tags: {
+    head_ref: headRef,
+    head_sha: headSha,
+    diffing_library: 'pixelmatch',
+    ...getOSTags(),
+  },
 });
 
 Sentry.configureScope(scope => {


### PR DESCRIPTION
I'll split the runs to run on odiff/pixelmatch for a while so we can gracefully introduce the new diffing library while still collecting the data about it. This will help us quantify improvements or regressions as we switch over