### PR TITLE
feat: Support naming the Visual Snapshot check differently

### DIFF
--- a/src/api/startBuild.ts
+++ b/src/api/startBuild.ts
@@ -35,7 +35,7 @@ export async function startBuild({
     core.debug(`sha/ref: ${head_ref}, ${head_sha}`);
     const result = await post(
       '/build',
-      {owner, repo, head_sha, head_ref},
+      {owner, repo, head_sha, head_ref, github_check_name: name},
       {
         'x-padding-token': token,
       }


### PR DESCRIPTION
In the backend [we landed](https://github.com/getsentry/cloud-run-padding/pull/30) a feature to allow naming the Visual Snapshot check differently.

This allows supporting having multiple set of Visual Snapshots. See [Sentry PR](https://github.com/getsentry/sentry/pull/35851) prototyping the idea.

Here's a screenshot of a [Visual Snapshot for Chartcuterie](https://github.com/getsentry/sentry/pull/35851/checks?check_run_id=7025064760):
<img width="251" alt="image" src="https://user-images.githubusercontent.com/44410/175319406-6fdf75b6-4c66-4d03-b9d1-3dbf112ee66d.png">