### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Get version
       id: get-version
-      run: echo "::set-output name=version::$(sentry-cli releases propose-version)"
+      run: echo "version=$(sentry-cli releases propose-version)" >> "$GITHUB_OUTPUT"
 
     - run: yarn lint
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos