### PR TITLE
feat: `getArtifactsForBranchAndWorkflow` to filter by `head_sha` via API

### DIFF
--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -1,91 +1,102 @@
-const listWorkflowRunsMock = jest.fn(async () =>
-  Promise.resolve({
-    data: {
-      workflow_runs: [
-        {
-          id: 152081708,
-          node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
-          head_branch: 'main',
-          head_sha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
-          run_number: 172,
-          event: 'push',
-          status: 'completed',
-          conclusion: 'success',
-          workflow_id: 1154499,
-          url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708',
-          html_url:
-            'https://github.com/getsentry/sentry/actions/runs/152081708',
-          pull_requests: [],
-          created_at: '2020-06-29T23:42:39Z',
-          updated_at: '2020-06-29T23:56:40Z',
-          jobs_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/jobs',
-          logs_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/logs',
-          check_suite_url:
-            'https://api.github.com/repos/getsentry/sentry/check-suites/856201749',
-          artifacts_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/artifacts',
-          cancel_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/cancel',
-          rerun_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/rerun',
-          workflow_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/workflows/1154499',
-          head_commit: {
-            id: '5e19cbbea129a173dc79d4634df0fdaece933b06',
-            tree_id: '332a699162888947ea062892169d9d81a9c906fe',
-            message: 'remove wait for animations',
-            timestamp: '2020-06-29T23:42:25Z',
-            author: {name: 'Billy Vong', email: 'billy@sentry.io'},
-            committer: {name: 'Billy Vong', email: 'billy@sentry.io'},
-          },
-          repository: {},
-          head_repository: {
-            full_name: 'getsentry/sentry',
-          },
-        },
-        {
-          id: 152081707,
-          node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
-          head_branch: 'main',
-          head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
-          run_number: 171,
-          event: 'push',
-          status: 'completed',
-          conclusion: 'success',
-          workflow_id: 1154498,
-          url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708',
-          html_url:
-            'https://github.com/getsentry/sentry/actions/runs/152081708',
-          pull_requests: [],
-          created_at: '2020-06-29T23:42:39Z',
-          updated_at: '2020-06-29T23:56:40Z',
-          jobs_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/jobs',
-          logs_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/logs',
-          check_suite_url:
-            'https://api.github.com/repos/getsentry/sentry/check-suites/856201749',
-          artifacts_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/artifacts',
-          cancel_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/cancel',
-          rerun_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/rerun',
-          workflow_url:
-            'https://api.github.com/repos/getsentry/sentry/actions/workflows/1154499',
-          repository: {},
-          head_repository: {
-            full_name: 'getsentry/sentry',
-          },
-        },
-      ],
+const listWorkflowRunsMock = jest.fn(async opts => {
+  const workflowRuns = [
+    {
+      id: 152081708,
+      node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
+      head_branch: 'main',
+      head_sha: '5e19cbbea129a173dc79d4634df0fdaece933b06',
+      run_number: 172,
+      event: 'push',
+      status: 'completed',
+      conclusion: 'success',
+      workflow_id: 1154499,
+      url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708',
+      html_url: 'https://github.com/getsentry/sentry/actions/runs/152081708',
+      pull_requests: [],
+      created_at: '2020-06-29T23:42:39Z',
+      updated_at: '2020-06-29T23:56:40Z',
+      jobs_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/jobs',
+      logs_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/logs',
+      check_suite_url:
+        'https://api.github.com/repos/getsentry/sentry/check-suites/856201749',
+      artifacts_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/artifacts',
+      cancel_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/cancel',
+      rerun_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/rerun',
+      workflow_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/workflows/1154499',
+      head_commit: {
+        id: '5e19cbbea129a173dc79d4634df0fdaece933b06',
+        tree_id: '332a699162888947ea062892169d9d81a9c906fe',
+        message: 'remove wait for animations',
+        timestamp: '2020-06-29T23:42:25Z',
+        author: {name: 'Billy Vong', email: 'billy@sentry.io'},
+        committer: {name: 'Billy Vong', email: 'billy@sentry.io'},
+      },
+      repository: {},
+      head_repository: {
+        full_name: 'getsentry/sentry',
+      },
     },
-  })
-);
+    {
+      id: 152081707,
+      node_id: 'MDExOldvcmtmbG93UnVuMTUyMDgxNzA4',
+      head_branch: 'main',
+      head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
+      run_number: 171,
+      event: 'push',
+      status: 'completed',
+      conclusion: 'success',
+      workflow_id: 1154498,
+      url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708',
+      html_url: 'https://github.com/getsentry/sentry/actions/runs/152081708',
+      pull_requests: [],
+      created_at: '2020-06-29T23:42:39Z',
+      updated_at: '2020-06-29T23:56:40Z',
+      jobs_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/jobs',
+      logs_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/logs',
+      check_suite_url:
+        'https://api.github.com/repos/getsentry/sentry/check-suites/856201749',
+      artifacts_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/artifacts',
+      cancel_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/cancel',
+      rerun_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/runs/152081708/rerun',
+      workflow_url:
+        'https://api.github.com/repos/getsentry/sentry/actions/workflows/1154499',
+      repository: {},
+      head_repository: {
+        full_name: 'getsentry/sentry',
+      },
+    },
+  ];
+  // TODO: Not great, too much mocking of octokit functionality here
+  const filtered = workflowRuns.filter(
+    workflowRun =>
+      (!opts.branch || opts.branch === workflowRun.head_branch) &&
+      (!opts.status ||
+        opts.status === workflowRun.conclusion ||
+        opts.status === workflowRun.status) &&
+      (!opts.head_sha || opts.head_sha === workflowRun.head_sha)
+  );
+
+  return Promise.resolve({
+    data: {
+      total_count: filtered.length, // Not totally accurate, depends on page limit etc
+      workflow_runs: filtered,
+    },
+  });
+});
+
 export const getOctokit = jest.fn(() => ({
   paginate: {
     // @ts-ignore

--- a/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
+++ b/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
@@ -17,8 +17,8 @@ test('it gets workflow runs and a branch and workflow id and then gets artifacts
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
     branch: 'main',
-    per_page: 10,
     status: 'success',
+    head_sha: undefined,
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({

--- a/__tests__/api/retrieveBaseSnapshots.test.ts
+++ b/__tests__/api/retrieveBaseSnapshots.test.ts
@@ -25,8 +25,8 @@ test('only downloads and returns base if base and merge base are the same', asyn
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
     branch: 'main',
-    per_page: 10,
     status: 'success',
+    head_sha: undefined,
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
@@ -74,8 +74,8 @@ test('downloads and returns base and merge base', async function () {
     repo: 'sentry',
     workflow_id: 'acceptance.yml',
     branch: 'main',
-    per_page: 10,
     status: 'success',
+    head_sha: '11111111l129a173dc79d4634df0fdaece933b06',
   });
 
   expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "@actions/github": "^5.0.3",
+    "@actions/github": "^5.1.1",
     "@actions/glob": "^0.3.0",
     "@actions/io": "^1.1.2",
     "@google-cloud/storage": "^5.4.0",

--- a/src/api/getArtifactsForBranchAndWorkflow.ts
+++ b/src/api/getArtifactsForBranchAndWorkflow.ts
@@ -53,7 +53,7 @@ export async function getArtifactsForBranchAndWorkflow(
     owner,
     repo,
     // Below is typed incorrectly, it needs to be a string but typed as number
-    workflow_id: (workflow_id as unknown) as number,
+    workflow_id,
     branch,
     status: 'success',
     head_sha: commit,

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
   dependencies:
     "@actions/io" "^1.0.1"
 
-"@actions/github@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@actions/github/-/github-5.0.3.tgz#b305765d6173962d113451ea324ff675aa674f35"
-  integrity sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==
+"@actions/github@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-5.1.1.tgz#40b9b9e1323a5efcf4ff7dadd33d8ea51651bbcb"
+  integrity sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==
   dependencies:
     "@actions/http-client" "^2.0.1"
     "@octokit/core" "^3.6.0"


### PR DESCRIPTION
Previously this was done by code as the API did not support passing `head_sha` to filter.
