### PR TITLE
Don't do anything if there are no images to activate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -317,11 +317,10 @@ async function run(): Promise<void> {
       destinationRoot: `${gcsDestination}/results`,
     });
     gcsSpan?.finish();
-    const changedArray = [...changedSnapshots];
     const results: BuildResults = {
       terminationReason,
       baseFilesLength: baseFiles.length,
-      changed: changedArray,
+      changed: [...changedSnapshots],
       missing: [...missingSnapshots],
       added: [...newSnapshots],
     };
@@ -332,6 +331,7 @@ async function run(): Promise<void> {
     } else {
       transaction?.setTag('snapshots.approvalRequired', 'false');
     }
+    core.info(`Results: ${JSON.stringify(results, null, 2)}`);
     core.endGroup();
 
     core.startGroup('Generating image gallery...');

--- a/src/template/index.ejs
+++ b/src/template/index.ejs
@@ -268,6 +268,9 @@
           this.setState({
             active,
           });
+          if (all.length === 0) {
+            return;
+          }
           const target = document.querySelector(
             `#${cleanSelector(all[active])}`
           );


### PR DESCRIPTION
I was trying to debug the visual snapshot showing different results in the action summary vs the generated index.html and noticed this error in the logs where no changes (i.e. `all = []`) will throw an error on `cleanSelector(all[active])}` because `all[0]` results in a call `cleanSelector(undefined)`.

The logging I've added to try and make it easier to debug issues in the future.