### PR TITLE
Run yarn dist as part of test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,4 @@ jobs:
       - run: yarn lint
       - run: yarn test:integration
       - run: yarn test:unit
+      - run: yarn dist

--- a/src/api/startBuild.ts
+++ b/src/api/startBuild.ts
@@ -23,7 +23,7 @@ export async function startBuild({
   headSha: head_sha,
   headRef: head_ref,
   name = 'Visual Snapshot',
-}: Params): Promise<number | bent.ValidResponse | null> {
+}: Params): Promise<any> {
   if (process.env.ACTION_LOCAL_RUN === 'true') {
     return null;
   }


### PR DESCRIPTION
This reverts the type change to startBuild to get things building (I'm honestly not sure why this works at all, but given that we are relying on this  action less, I'm going to leave it as is for now)