### PR TITLE
fix: Download base artifact from current workflow

### DIFF
--- a/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
+++ b/__tests__/api/getArtifactsForBranchAndWorkflow.test.ts
@@ -32,35 +32,3 @@ test('it gets workflow runs and a branch and workflow id and then gets artifacts
       'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
   });
 });
-
-test('it gets workflow runs when status is undefined', async function () {
-  const octokit = github.getOctokit('token');
-
-  const results = await getArtifactsForBranchAndWorkflow(octokit, {
-    owner: 'getsentry',
-    repo: 'sentry',
-    workflow_id: 'acceptance.yml',
-    branch: '',
-    artifactName: 'visual-snapshots',
-    status: null,
-  });
-
-  expect(octokit.rest.actions.listWorkflowRuns).toHaveBeenCalledWith({
-    owner: 'getsentry',
-    repo: 'sentry',
-    workflow_id: 'acceptance.yml',
-    branch: '',
-    head_sha: undefined,
-  });
-
-  expect(octokit.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledWith({
-    owner: 'getsentry',
-    repo: 'sentry',
-    run_id: 152081708,
-  });
-
-  expect(results?.artifact).toMatchObject({
-    url:
-      'https://api.github.com/repos/getsentry/sentry/actions/artifacts/9808919',
-  });
-});

--- a/src/api/retrieveBaseSnapshots.ts
+++ b/src/api/retrieveBaseSnapshots.ts
@@ -32,7 +32,6 @@ export async function retrieveBaseSnapshots(
     basePath,
     mergeBasePath,
     mergeBaseSha,
-    status,
   }: RetrieveBaseSnapshotsParams
 ) {
   const baseArtifacts = await getArtifactsForBranchAndWorkflow(octokit, {
@@ -41,7 +40,6 @@ export async function retrieveBaseSnapshots(
     workflow_id,
     branch,
     artifactName,
-    status,
   });
 
   if (!baseArtifacts) {


### PR DESCRIPTION
The base artifact was actually being download from an old workflow run instead of the current workflow being run.

Switching to downloadSnapshots fixes this as it uses '@actions/artifact' node module to download the artifact, but it results in a slightly different directory structure that needed to be handled.

Tested in this run: https://github.com/getsentry/getsentry/actions/runs/4492158817/jobs/7901819754

```
  Results: {
    "terminationReason": null,
    "baseFilesLength": 9,
    "changed": [
      "jest/subscription-overview-displays-limited-context-for-members.png"
    ],
    "missing": [],
    "added": []
  }
``` 